### PR TITLE
Dependency Security Update: setuptools CVE-2024-6345

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,5 +14,5 @@ twine~=3.4.1
 wheel~=0.38.1
 packaging~=21.0
 pytz~=2021.3
-setuptools>=65.5.1
+setuptools>=70.0.0
 dohq-artifactory==0.8.1


### PR DESCRIPTION
This PR updates Setuptools to version with fix for [CVE-2024-6345](https://nvd.nist.gov/vuln/detail/CVE-2024-6345)

https://seeq.atlassian.net/browse/CRAB-44538